### PR TITLE
fixing log output... could be more verbose

### DIFF
--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -212,7 +212,7 @@ def install_nbextension_python(package, overwrite=False, symlink=False,
         dest = nbext['dest']
         require = nbext['require']
         if logger:
-            logger.info(src, dest, require)
+            logger.info("%s %s %s" % (src, dest, require))
         install_nbextension(src, overwrite=overwrite, symlink=symlink,
             user=user, sys_prefix=sys_prefix, prefix=prefix, nbextensions_dir=nbextensions_dir,
             destination=dest, logger=logger


### PR DESCRIPTION
For https://github.com/jupyter/notebook/pull/879

Encountered "not all arguments could be converted" when running the notebook server with debug on. This is the minimum fix (short of taking it out)... the local landscape seemed `%`-friendly, but can change to `format`.

Also, it's a bit terse: it could also be something like "Install Preflight: % from %s, will require %". The uninstall command is similarly terse.

Regarding the `require`: since we've decided that one must always do install/enable as two steps (unless I am missing something), it shouldn't even be looked at.
