### PR TITLE
Normalize path to fix symlink creation

### DIFF
--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -11,7 +11,7 @@ import shutil
 import sys
 import tarfile
 import zipfile
-from os.path import basename, join as pjoin
+from os.path import basename, join as pjoin, normpath
 
 try:
     from urllib.parse import urlparse  # Py3
@@ -180,7 +180,7 @@ def install_nbextension(path, overwrite=False, symlink=False,
         if not destination:
             destination = basename(path)
         destination = cast_unicode_py2(destination)
-        full_dest = pjoin(nbext, destination)
+        full_dest = normpath(pjoin(nbext, destination))
         if overwrite and os.path.lexists(full_dest):
             if logger:
                 logger.info("Removing: %s" % full_dest)


### PR DESCRIPTION
When installing an nbextension as a symlink we are getting:

```
  File "/Users/malev/miniconda2/envs/notebook/lib/python2.7/site-packages/notebook/nbextensions.py", line 198, in install_nbextension
    os.symlink(path, full_dest)
OSError: [Errno 2] No such file or directory
```

If `dest` (user input variable) has a `\` at the end, the creation of the symlink will fail.
This can be fixed by normalizing the path before creating the string.
