### PR TITLE
Add command template for nbextension enable after install

### DIFF
--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -211,6 +211,13 @@ def install_nbextension(path, overwrite=False, symlink=False,
             src = path
             _maybe_copy(src, full_dest, logger=logger)
     
+    if logger:
+        logger.info(
+            "\nTo initialize this nbextension in the browser every time the"
+            " notebook (or other app) loads:\n\n"
+            "      jupyter nbextension enable\n"
+        )
+
     return full_dest
 
 

--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -210,13 +210,6 @@ def install_nbextension(path, overwrite=False, symlink=False,
         else:
             src = path
             _maybe_copy(src, full_dest, logger=logger)
-    
-    if logger:
-        logger.info(
-            "\nTo initialize this nbextension in the browser every time the"
-            " notebook (or other app) loads:\n\n"
-            "      jupyter nbextension enable\n"
-        )
 
     return full_dest
 
@@ -346,6 +339,9 @@ def _set_nbextension_state(section, require, state,
             require
         ))
     cm.update(section, {"load_extensions": {require: state}})
+
+    validate_nbextension(require, logger=logger)
+
     return cm.get(section).get(require) == state
 
 
@@ -510,11 +506,11 @@ def validate_nbextension(require, logger=None):
     
     if logger:
         if warnings:
-            logger.warn("- Validating: problems found:")
+            logger.warn("      - Validating: problems found:")
             map(logger.warn, warnings)
             map(logger.info, infos)
         else:
-            logger.info("- Validating: {}".format(GREEN_OK))
+            logger.info("      - Validating: {}".format(GREEN_OK))
     
     return warnings
 
@@ -684,16 +680,27 @@ class InstallNBExtensionApp(BaseNBExtensionApp):
         
         install = install_nbextension_python if self.python else install_nbextension
         
-        install(self.extra_args[0],
-            overwrite=self.overwrite,
-            symlink=self.symlink,
-            user=self.user,
-            sys_prefix=self.sys_prefix,
-            prefix=self.prefix,
-            nbextensions_dir=self.nbextensions_dir,
-            logger=self.log
-        )
-    
+        full_dests = install(self.extra_args[0],
+                             overwrite=self.overwrite,
+                             symlink=self.symlink,
+                             user=self.user,
+                             sys_prefix=self.sys_prefix,
+                             prefix=self.prefix,
+                             nbextensions_dir=self.nbextensions_dir,
+                             logger=self.log)
+
+        if full_dests:
+            self.log.info(
+                "\nTo initialize this nbextension in the browser every time"
+                " the notebook (or other app) loads:\n\n"
+                "      jupyter nbextension enable {}{}{}{}\n".format(
+                    self.extra_args[0] if self.python else "<the entry point>",
+                    " --user" if self.user else "",
+                    " --py" if self.python else "",
+                    " --sys-prefix" if self.sys_prefix else ""
+                )
+            )
+
     def start(self):
         """Perform the App's function as configured"""
         if not self.extra_args:
@@ -852,16 +859,18 @@ class ListNBExtensionsApp(BaseNBExtensionApp):
         """List all the nbextensions"""
         config_dirs = [os.path.join(p, 'nbconfig') for p in jupyter_config_path()]
         
+        self.log.info("Known nbextensions:")
+        
         for config_dir in config_dirs:
-            self.log.info('config dir: {}'.format(config_dir))
+            self.log.info('  config dir: {}'.format(config_dir))
             cm = BaseJSONConfigManager(parent=self, config_dir=config_dir)
             for section in NBCONFIG_SECTIONS:
                 data = cm.get(section)
                 if 'load_extensions' in data:
-                    self.log.info('  {} section'.format(section))
+                    self.log.info('    {} section'.format(section))
                     
                     for require, enabled in data['load_extensions'].items():
-                        self.log.info('    {} {}'.format(
+                        self.log.info('      {} {}'.format(
                             require,
                             GREEN_ENABLED if enabled else RED_DISABLED))
                         if enabled:


### PR DESCRIPTION
> Answers https://github.com/jupyter/notebook/pull/879#issuecomment-193404634

Here's some sample output:

``` shell
nbollweg@rocinante:~/Documents/projects/notebook (nbext-pain-install-msg)$ jupyter nbextension install --py nbpresent --sys-prefix --overwrite --symlink
Unrecognized JSON config file version, assuming version 1
Installing /Users/nbollweg/Documents/projects/nbpresent/nbpresent/static/nbpresent -> nbpresent
Removing: /Users/nbollweg/miniconda/envs/nbpresent42/share/jupyter/nbextensions/nbpresent
Symlinking: /Users/nbollweg/miniconda/envs/nbpresent42/share/jupyter/nbextensions/nbpresent -> /Users/nbollweg/Documents/projects/nbpresent/nbpresent/static/nbpresent
- Validating: OK

    To initialize this nbextension in the browser every time the notebook (or other app) loads:

          jupyter nbextension enable nbpresent --py --sys-prefix
```

If not using `--py`, the templated command is not as good:

``` shell
nbollweg@rocinante:~/Documents/projects/notebook (nbext-pain-install-msg)$ jupyter nbextension install /Users/nbollweg/Documents/projects/nbpresent/nbpresent/static/nbpresent --sys-prefix --overwrite --symlink
Unrecognized JSON config file version, assuming version 1
Removing: /Users/nbollweg/miniconda/envs/nbpresent42/share/jupyter/nbextensions/nbpresent
Symlinking: /Users/nbollweg/miniconda/envs/nbpresent42/share/jupyter/nbextensions/nbpresent -> /Users/nbollweg/Documents/projects/nbpresent/nbpresent/static/nbpresent

    To initialize this nbextension in the browser every time the notebook (or other app) loads:

          jupyter nbextension enable <the entry point> --sys-prefix
```

I suppose we _could_ grep for the magic name to find the entrypoint, but that seems error-prone: i.e. if you have more than one extension in a single folder, etc.
