### PR TITLE
Update user config by default (not system) for extension enable/disable

### DIFF
--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -359,9 +359,9 @@ def _set_nbextension_state_python(state, package, user, sys_prefix,
     package : str
         Importable Python package (no dotted-notation!) exposing the
         magic-named `_jupyter_nbextension_paths` function
-    user : bool [default: False]
+    user : bool
         Whether to enable in the user's nbextensions directory.
-    sys_prefix : bool [default: False]
+    sys_prefix : bool
         Enable/disable in the sys.prefix, i.e. environment
     logger : Jupyter logger [optional]
         Logger instance to use

--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -308,7 +308,7 @@ def uninstall_nbextension_python(package,
 
 
 def _set_nbextension_state(section, require, state,
-                           user=False, sys_prefix=False, logger=None):
+                           user=True, sys_prefix=False, logger=None):
     """Set whether the section's frontend should require the named nbextension
 
     Returns True if the final state is the one requested.
@@ -321,11 +321,10 @@ def _set_nbextension_state(section, require, state,
         An importable AMD module inside the nbextensions static path
     state : bool
         The state in which to leave the extension
-    user : bool [default: False]
-        Whether to check the user's .jupyter/nbextensions directory.
-        Otherwise check a system-wide install (e.g. /usr/local/share/jupyter/nbextensions).
+    user : bool [default: True]
+        Whether to update the user's .jupyter/nbextensions directory
     sys_prefix : bool [default: False]
-        Install into the sys.prefix, i.e. environment
+        Whether to update the sys.prefix, i.e. environment
     logger : Jupyter logger [optional]
         Logger instance to use
     """
@@ -376,7 +375,7 @@ def _set_nbextension_state_python(state, package, user, sys_prefix,
             for nbext in nbexts]
 
 
-def enable_nbextension(section, require, user=False, sys_prefix=False,
+def enable_nbextension(section, require, user=True, sys_prefix=False,
                        logger=None):
     """Enable a named nbextension
 
@@ -389,7 +388,7 @@ def enable_nbextension(section, require, user=False, sys_prefix=False,
         The section of the server to change, one of NBCONFIG_SECTIONS
     require : string
         An importable AMD module inside the nbextensions static path
-    user : bool [default: False]
+    user : bool [default: True]
         Whether to enable in the user's nbextensions directory.
     sys_prefix : bool [default: False]
         Whether to enable in the sys.prefix, i.e. environment
@@ -402,7 +401,7 @@ def enable_nbextension(section, require, user=False, sys_prefix=False,
                                   logger=logger)
 
 
-def disable_nbextension(section, require, user=False, sys_prefix=False,
+def disable_nbextension(section, require, user=True, sys_prefix=False,
                         logger=None):
     """Disable a named nbextension
     
@@ -415,7 +414,7 @@ def disable_nbextension(section, require, user=False, sys_prefix=False,
         The section of the server to change, one of NBCONFIG_SECTIONS
     require : string
         An importable AMD module inside the nbextensions static path
-    user : bool [default: False]
+    user : bool [default: True]
         Whether to enable in the user's nbextensions directory.
     sys_prefix : bool [default: False]
         Whether to enable in the sys.prefix, i.e. environment
@@ -428,7 +427,7 @@ def disable_nbextension(section, require, user=False, sys_prefix=False,
                                   logger=logger)
 
 
-def enable_nbextension_python(package, user=False, sys_prefix=False,
+def enable_nbextension_python(package, user=True, sys_prefix=False,
                               logger=None):
     """Enable some nbextensions associated with a Python package.
 
@@ -441,7 +440,7 @@ def enable_nbextension_python(package, user=False, sys_prefix=False,
     package : str
         Importable Python package (no dotted-notation!) exposing the
         magic-named `_jupyter_nbextension_paths` function
-    user : bool [default: False]
+    user : bool [default: True]
         Whether to enable in the user's nbextensions directory.
     sys_prefix : bool [default: False]
         Whether to enable in the sys.prefix, i.e. environment
@@ -452,7 +451,7 @@ def enable_nbextension_python(package, user=False, sys_prefix=False,
                                          logger=logger)
 
 
-def disable_nbextension_python(package, user=False, sys_prefix=False,
+def disable_nbextension_python(package, user=True, sys_prefix=False,
                                logger=None):
     """Disable some nbextensions associated with a Python package.
     
@@ -464,7 +463,7 @@ def disable_nbextension_python(package, user=False, sys_prefix=False,
     package : str
         Importable Python package (no dotted-notation!) exposing the
         magic-named `_jupyter_nbextension_paths` function
-    user : bool [default: False]
+    user : bool [default: True]
         Whether to enable in the user's nbextensions directory.
     sys_prefix : bool [default: False]
         Whether to enable in the sys.prefix, i.e. environment
@@ -780,6 +779,7 @@ class ToggleNBExtensionApp(BaseNBExtensionApp):
     section = Unicode('notebook', config=True,
           help="""Which config section to add the extension to, 'common' will affect all pages."""
     )
+    user = Bool(True, config=True, help="Whether to do a user configuration")
 
     aliases = {'section': 'ToggleNBExtensionApp.section'}
     

--- a/notebook/serverextensions.py
+++ b/notebook/serverextensions.py
@@ -30,7 +30,7 @@ class ArgumentConflict(ValueError):
 
 
 def toggle_serverextension_python(import_name, enabled=None, parent=None,
-                                  user=False, sys_prefix=False, logger=None):
+                                  user=True, sys_prefix=False, logger=None):
     """Toggle a server extension.
 
     By default, toggles the extension in the system-wide Jupyter configuration
@@ -46,7 +46,7 @@ def toggle_serverextension_python(import_name, enabled=None, parent=None,
         Toggle state for the extension.  Set to None to toggle, True to enable,
         and False to disable the extension.
     parent : Configurable [default: None]
-    user : bool [default: False]
+    user : bool [default: True]
         Toggle in the user's configuration location (e.g. ~/.jupyter).
     sys_prefix : bool [default: False]
         Toggle in the current Python environment's configuration location
@@ -161,7 +161,7 @@ class ToggleServerExtensionApp(BaseNBExtensionApp):
     aliases = {}
     flags = flags
 
-    user = Bool(False, config=True, help="Whether to do a user install")
+    user = Bool(True, config=True, help="Whether to do a user install")
     sys_prefix = Bool(False, config=True, help="Use the sys.prefix as the prefix")
     python = Bool(False, config=True, help="Install from a Python package")
     

--- a/notebook/tests/test_serverextensions.py
+++ b/notebook/tests/test_serverextensions.py
@@ -1,11 +1,15 @@
 from unittest import TestCase
+
 from traitlets.config.manager import BaseJSONConfigManager
+
 from notebook.serverextensions import toggle_serverextension_python
 from notebook.nbextensions import _get_config_dir
+
 
 class TestInstallServerExtension(TestCase):
     def _inject_mock_extension(self):
         outer_file = __file__
+
         class mock():
             __file__ = outer_file
 
@@ -18,26 +22,22 @@ class TestInstallServerExtension(TestCase):
         import sys
         sys.modules['mockextension'] = mock
 
-    def _get_config(self, user=False):
-        cm = BaseJSONConfigManager(config_dir=_get_config_dir(user=True))
+    def _get_config(self, user=True):
+        cm = BaseJSONConfigManager(config_dir=_get_config_dir(user))
         data = cm.get("jupyter_notebook_config")
-        return (
-            data.setdefault("NotebookApp", {})
-            .setdefault("nbserver_extensions", {})
-        )
+        return data.get("NotebookApp", {}).get("nbserver_extensions", {})
 
     def test_enable(self):
         self._inject_mock_extension()
-        toggle_serverextension_python('mockextension', True, user=True)
+        toggle_serverextension_python('mockextension', True)
 
         config = self._get_config()
         assert config['mockextension']
 
     def test_disable(self):
         self._inject_mock_extension()
-        toggle_serverextension_python('mockextension', True, user=True)
-        toggle_serverextension_python('mockextension', False, user=True)
+        toggle_serverextension_python('mockextension', True)
+        toggle_serverextension_python('mockextension', False)
 
         config = self._get_config()
         assert not config['mockextension']
-


### PR DESCRIPTION
> See https://github.com/jupyter/notebook/pull/879

This restores the previous default of `--user` for `enable` and `disable`. `install` still defaults to system global.

@minrk @ellisonbg Is this the right behavior?
