### PR TITLE
Restoring --debug and --log-level

### DIFF
--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -574,8 +574,11 @@ def validate_nbextension_python(spec, full_dest, logger=None):
 from traitlets import Bool, Unicode, Any
 from jupyter_core.application import JupyterApp
 
-
-_base_flags = {
+_base_flags = {}
+_base_flags.update(JupyterApp.flags)
+_base_flags.pop("y", None)
+_base_flags.pop("generate-config", None)
+_base_flags.update({
     "user" : ({
         "BaseNBExtensionApp" : {
             "user" : True,
@@ -591,7 +594,7 @@ _base_flags = {
             "python" : True,
         }}, "Install from a Python package"
     )
-}
+})
 _base_flags['python'] = _base_flags['py']
 
 class BaseNBExtensionApp(JupyterApp):

--- a/notebook/serverextensions.py
+++ b/notebook/serverextensions.py
@@ -13,7 +13,7 @@ import sys
 from jupyter_core.paths import jupyter_config_path
 from ._version import __version__
 from .nbextensions import (
-    BaseNBExtensionApp, _get_config_dir,
+    JupyterApp, BaseNBExtensionApp, _get_config_dir,
     GREEN_ENABLED, RED_DISABLED,
     GREEN_OK, RED_X,
 )
@@ -132,8 +132,11 @@ def validate_serverextension(import_name, logger=None):
 # Applications
 # ----------------------------------------------------------------------
 
-
-flags = {
+flags = {}
+flags.update(JupyterApp.flags)
+flags.pop("y", None)
+flags.pop("generate-config", None)
+flags.update({
     "user" : ({
         "ToggleServerExtensionApp" : {
             "user" : True,
@@ -149,7 +152,7 @@ flags = {
             "python" : True,
         }}, "Install from a Python package"
     ),
-}
+})
 flags['python'] = flags['py']
 
 


### PR DESCRIPTION
> See https://github.com/jupyter/notebook/pull/879

This restores the flags for `--debug` and `--log-level` for all the apps.

I'm popping `--y` and `--generate-config`, as I don't what value they would have.

`config` could be resonable, so leaving it.

Feedback welcome!
