### PR TITLE
unicode everywhere for logging

### DIFF
--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -492,12 +492,12 @@ def validate_nbextension(require, logger=None):
     js_exists = False
     for exts in _nbextension_dirs():
         # Does the Javascript entrypoint actually exist on disk?
-        js = "{}.js".format(os.path.join(exts, *require.split("/")))
+        js = u"{}.js".format(os.path.join(exts, *require.split("/")))
         js_exists = os.path.exists(js)
         if js_exists:
             break
 
-    require_tmpl = "- require? {} {}"
+    require_tmpl = u"        - require? {} {}"
     if js_exists:
         infos.append(require_tmpl.format(GREEN_OK, require))
     else:
@@ -505,11 +505,11 @@ def validate_nbextension(require, logger=None):
     
     if logger:
         if warnings:
-            logger.warn("      - Validating: problems found:")
+            logger.warn(u"      - Validating: problems found:")
             map(logger.warn, warnings)
             map(logger.info, infos)
         else:
-            logger.info("      - Validating: {}".format(GREEN_OK))
+            logger.info(u"      - Validating: {}".format(GREEN_OK))
     
     return warnings
 
@@ -541,28 +541,28 @@ def validate_nbextension_python(spec, full_dest, logger=None):
 
     section = spec.get("section", None)
     if section in NBCONFIG_SECTIONS:
-        infos.append("  {} section: {}".format(GREEN_OK, section))
+        infos.append(u"  {} section: {}".format(GREEN_OK, section))
     else:
-        warnings.append("  {}  section: {}".format(RED_X, section))
+        warnings.append(u"  {}  section: {}".format(RED_X, section))
 
     require = spec.get("require", None)
     if require is not None:
         require_path = os.path.join(
             full_dest[0:-len(spec["dest"])],
-            "{}.js".format(require))
+            u"{}.js".format(require))
         if os.path.exists(require_path):
-            infos.append("  {} require: {}".format(GREEN_OK, require_path))
+            infos.append(u"  {} require: {}".format(GREEN_OK, require_path))
         else:
-            warnings.append("  {}  require: {}".format(RED_X, require_path))
+            warnings.append(u"  {}  require: {}".format(RED_X, require_path))
 
     if logger:
         if warnings:
             logger.warn("- Validating: problems found:")
             [logger.warn(warning) for warning in warnings]
             [logger.info(info) for info in infos]
-            logger.warn("Full spec: {}".format(spec))
+            logger.warn(u"Full spec: {}".format(spec))
         else:
-            logger.info("- Validating: {}".format(GREEN_OK))
+            logger.info(u"- Validating: {}".format(GREEN_OK))
 
     return warnings
 
@@ -690,7 +690,7 @@ class InstallNBExtensionApp(BaseNBExtensionApp):
 
         if full_dests:
             self.log.info(
-                "\nTo initialize this nbextension in the browser every time"
+                u"\nTo initialize this nbextension in the browser every time"
                 " the notebook (or other app) loads:\n\n"
                 "      jupyter nbextension enable {}{}{}{}\n".format(
                     self.extra_args[0] if self.python else "<the entry point>",
@@ -862,15 +862,15 @@ class ListNBExtensionsApp(BaseNBExtensionApp):
         self.log.info("Known nbextensions:")
         
         for config_dir in config_dirs:
-            self.log.info('  config dir: {}'.format(config_dir))
+            self.log.info(u'  config dir: {}'.format(config_dir))
             cm = BaseJSONConfigManager(parent=self, config_dir=config_dir)
             for section in NBCONFIG_SECTIONS:
                 data = cm.get(section)
                 if 'load_extensions' in data:
-                    self.log.info('    {} section'.format(section))
+                    self.log.info(u'    {} section'.format(section))
                     
                     for require, enabled in data['load_extensions'].items():
-                        self.log.info('      {} {}'.format(
+                        self.log.info(u'      {} {}'.format(
                             require,
                             GREEN_ENABLED if enabled else RED_DISABLED))
                         if enabled:

--- a/notebook/serverextensions.py
+++ b/notebook/serverextensions.py
@@ -67,14 +67,14 @@ def toggle_serverextension_python(import_name, enabled=None, parent=None,
 
     if logger:
         if new_enabled:
-            logger.info("Enabling: %s" % (import_name))
+            logger.info(u"Enabling: %s" % (import_name))
         else:
-            logger.info("Disabling: %s" % (import_name))
+            logger.info(u"Disabling: %s" % (import_name))
 
     server_extensions[import_name] = new_enabled
 
     if logger:
-        logger.info("- Writing config: {}".format(config_dir))
+        logger.info(u"- Writing config: {}".format(config_dir))
 
     cm.update("jupyter_notebook_config", cfg)
 
@@ -111,13 +111,13 @@ def validate_serverextension(import_name, logger=None):
     except Exception:
         logger.warning("Error loading server extension %s", import_name)
 
-    import_msg = "     {} is {} importable?"
+    import_msg = u"     {} is {} importable?"
     if func is not None:
         infos.append(import_msg.format(GREEN_OK, import_name))
     else:
         warnings.append(import_msg.format(RED_X, import_name))
 
-    post_mortem = "      {} {} {}"
+    post_mortem = u"      {} {} {}"
     if logger:
         if warnings:
             [logger.info(info) for info in infos]
@@ -236,7 +236,7 @@ class ListServerExtensionsApp(BaseNBExtensionApp):
         """
         config_dirs = jupyter_config_path()
         for config_dir in config_dirs:
-            self.log.info('config dir: {}'.format(config_dir))
+            self.log.info(u'config dir: {}'.format(config_dir))
             cm = BaseJSONConfigManager(parent=self, config_dir=config_dir)
             data = cm.get("jupyter_notebook_config")
             server_extensions = (
@@ -244,7 +244,7 @@ class ListServerExtensionsApp(BaseNBExtensionApp):
                 .setdefault("nbserver_extensions", {})
             )
             for import_name, enabled in server_extensions.items():
-                self.log.info('    {} {}'.format(
+                self.log.info(u'    {} {}'.format(
                               import_name,
                               GREEN_ENABLED if enabled else RED_DISABLED))
                 validate_serverextension(import_name, self.log)
@@ -312,7 +312,7 @@ def _get_server_extension_metadata(package):
     """
     m = __import__(package)
     if not hasattr(m, '_jupyter_server_extension_paths'):
-        raise KeyError('The Python package {} does not include any valid server extensions'.format(package))
+        raise KeyError(u'The Python package {} does not include any valid server extensions'.format(package))
     return m, m._jupyter_server_extension_paths()
 
 if __name__ == '__main__':


### PR DESCRIPTION
> See https://github.com/jupyter/notebook/pull/879

Fixes previously-undiscovered issue on python 2.7 with unicode in javascript require names (could happen, i suppose):

https://travis-ci.org/jupyter/notebook/jobs/116540953#L560

Fun fact: that is very possibly the highest proportion of `u`s to total characters in a commit I've ever made.
