### PR TITLE
updates to nbextensions

### DIFF
--- a/docs/source/examples/Notebook/Distributing Jupyter Extensions as Python Packages.ipynb
+++ b/docs/source/examples/Notebook/Distributing Jupyter Extensions as Python Packages.ipynb
@@ -249,9 +249,9 @@
     "\n",
     "The user can install and enable the extensions with the following set of commands:\n",
     "```\n",
-    "jupyter serverextension install --py my_fancy_module [--sys-prefix|--user]\n",
     "jupyter nbextension install --py my_fancy_module [--sys-prefix|--user]\n",
-    "jupyter nbextension enable --py my_fancy_module [--sys-prefix]\n",
+    "jupyter nbextension enable --py my_fancy_module [--sys-prefix|--system]\n",
+    "jupyter serverextension enable --py my_fancy_module [--sys-prefix|--system]\n",
     "```"
    ]
   }

--- a/docs/source/examples/Notebook/Distributing Jupyter Extensions as Python Packages.ipynb
+++ b/docs/source/examples/Notebook/Distributing Jupyter Extensions as Python Packages.ipynb
@@ -60,10 +60,10 @@
     "\n",
     "A `pip` user that wants their configuration stored in their home directory would type the following command:\n",
     "```shell\n",
-    "jupyter serverextension enable --py helpful_package --user\n",
+    "jupyter serverextension enable --py helpful_package\n",
     "```\n",
     "\n",
-    "Alternatively, a `virtualenv` or `conda` user can pass `--sys-prefix` instead of `--user` which keeps their environment isolated and reproducible. For example:\n",
+    "Alternatively, a `virtualenv` or `conda` user can pass `--sys-prefix` which keeps their environment isolated and reproducible. For example:\n",
     "```shell\n",
     "# Make sure that your virtualenv or conda environment is activated\n",
     "[source] activate my-environment\n",
@@ -85,7 +85,7 @@
    "source": [
     "If a package also has an nbextension with frontend assets that must be available (but not neccessarily enabled by default), install these assets with the following command:\n",
     "```shell\n",
-    "jupyter nbextension install --py helpful_package --user # or --sys-prefix if using virtualenv or conda\n",
+    "jupyter nbextension install --py helpful_package # or --sys-prefix if using virtualenv or conda\n",
     "```"
    ]
   },
@@ -96,7 +96,7 @@
     "### Enable nbextension assets\n",
     "If a package has assets that should be loaded every time a Jupyter app (e.g. lab, notebook, dashboard, terminal) is loaded in the browser, the following command can be used to enable the nbextension:\n",
     "```shell\n",
-    "jupyter nbextension enable --py helpful_package --user # or --sys-prefix if using virtualenv or conda\n",
+    "jupyter nbextension enable --py helpful_package # or --sys-prefix if using virtualenv or conda\n",
     "```"
    ]
   },
@@ -180,7 +180,7 @@
     "### Install and enable the server extension\n",
     "Which a user can install with:\n",
     "```\n",
-    "jupyter serverextension enable --py my_module [--sys-prefix|--user]\n",
+    "jupyter serverextension enable --py my_module [--sys-prefix]\n",
     "```"
    ]
   },
@@ -251,7 +251,7 @@
     "```\n",
     "jupyter serverextension install --py my_fancy_module [--sys-prefix|--user]\n",
     "jupyter nbextension install --py my_fancy_module [--sys-prefix|--user]\n",
-    "jupyter nbextension enable --py my_fancy_module [--sys-prefix|--user]\n",
+    "jupyter nbextension enable --py my_fancy_module [--sys-prefix]\n",
     "```"
    ]
   }

--- a/docs/source/extending/frontend_extensions.rst
+++ b/docs/source/extending/frontend_extensions.rst
@@ -202,10 +202,12 @@ the prefix. For the action name, the following guidelines should be considered:
 Installing and enabling extensions
 ----------------------------------
 
-You can install your nbextension with the command:
+You can install your nbextension with the command::
 
-    jupyter nbextension install path/to/my_extension/
+    jupyter nbextension install path/to/my_extension/ [--user|--sys-prefix]
 
+The default installation is system-wide. You can use ``--user`` to do a per-user installation,
+or ``--sys-prefix`` to install to Python's prefix (e.g. in a virtual or conda environment).
 Where my_extension is the directory containing the Javascript files.
 This will copy it to a Jupyter data directory (the exact location is platform
 dependent - see :ref:`jupyter_path`).
@@ -214,11 +216,15 @@ For development, you can use the ``--symlink`` flag to symlink your extension
 rather than copying it, so there's no need to reinstall after changes.
 
 To use your extension, you'll also need to **enable** it, which tells the
-notebook interface to load it. You can do that with another command:
+notebook interface to load it. You can do that with another command::
 
-    jupyter nbextension enable my_extension/main
+    jupyter nbextension enable my_extension/main [--sys-prefix]
 
 The argument refers to the Javascript module containing your
 ``load_ipython_extension`` function, which is ``my_extension/main.js`` in this
 example. There is a corresponding ``disable`` command to stop using an
 extension without uninstalling it.
+
+.. versionchanged:: 4.2
+
+    Added ``--sys-prefix`` argument

--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -868,18 +868,24 @@ class ListNBExtensionsApp(BaseNBExtensionApp):
         """List all the nbextensions"""
         config_dirs = [os.path.join(p, 'nbconfig') for p in jupyter_config_path()]
         
-        self.log.info("Known nbextensions:")
+        print("Known nbextensions:")
         
         for config_dir in config_dirs:
-            self.log.info(u'  config dir: {}'.format(config_dir))
+            head = u'  config dir: {}'.format(config_dir)
+            head_shown = False
+
             cm = BaseJSONConfigManager(parent=self, config_dir=config_dir)
             for section in NBCONFIG_SECTIONS:
                 data = cm.get(section)
                 if 'load_extensions' in data:
-                    self.log.info(u'    {} section'.format(section))
+                    if not head_shown:
+                        # only show heading if there is an nbextension here
+                        print(head)
+                        head_shown = True
+                    print(u'    {} section'.format(section))
                     
                     for require, enabled in data['load_extensions'].items():
-                        self.log.info(u'      {} {}'.format(
+                        print(u'      {} {}'.format(
                             require,
                             GREEN_ENABLED if enabled else RED_DISABLED))
                         if enabled:

--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -588,12 +588,18 @@ _base_flags.update({
     "user" : ({
         "BaseNBExtensionApp" : {
             "user" : True,
-        }}, "Install to the user's Jupyter directory"
+        }}, "Apply the operation only for the given user"
+    ),
+    "system" : ({
+        "BaseNBExtensionApp" : {
+            "user" : False,
+            "sys_prefix": False,
+        }}, "Apply the operation system-wide"
     ),
     "sys-prefix" : ({
         "BaseNBExtensionApp" : {
             "sys_prefix" : True,
-        }}, "Use sys.prefix as the prefix for installing nbextensions"
+        }}, "Use sys.prefix as the prefix for installing nbextensions (for environments, packaging)"
     ),
     "py" : ({
         "BaseNBExtensionApp" : {
@@ -655,7 +661,7 @@ class InstallNBExtensionApp(BaseNBExtensionApp):
     
     Usage
     
-        jupyter nbextension install path/url
+        jupyter nbextension install path|url [--user|--sys-prefix]
     
     This copies a file or a folder into the Jupyter nbextensions directory.
     If a URL is given, it will be downloaded.
@@ -764,7 +770,7 @@ class UninstallNBExtensionApp(BaseNBExtensionApp):
         if len(self.extra_args)<arg_count:
             raise ValueError("not enough arguments")
         
-        if self.python:    
+        if self.python:
             uninstall_nbextension_python(self.extra_args[0], **kwargs)
         else:
             uninstall_nbextension(self.extra_args[0], self.extra_args[1], **kwargs)
@@ -783,12 +789,12 @@ class ToggleNBExtensionApp(BaseNBExtensionApp):
     """A base class for apps that enable/disable extensions"""
     name = "jupyter nbextension enable/disable"
     version = __version__
-    description = "Enable/disable an nbextension using frontend configuration files."
+    description = "Enable/disable an nbextension in configuration."
 
     section = Unicode('notebook', config=True,
           help="""Which config section to add the extension to, 'common' will affect all pages."""
     )
-    user = Bool(True, config=True, help="Whether to do a user configuration")
+    user = Bool(True, config=True, help="Apply the configuration only for the current user (default)")
 
     aliases = {'section': 'ToggleNBExtensionApp.section'}
     
@@ -847,14 +853,24 @@ class ToggleNBExtensionApp(BaseNBExtensionApp):
 class EnableNBExtensionApp(ToggleNBExtensionApp):
     """An App that enables nbextensions"""
     name = "jupyter nbextension enable"
-    description = "Enable an nbextension using frontend configuration files."
+    description = """
+    Enable an nbextension in frontend configuration.
+    
+    Usage
+        jupyter nbextension enable [--system|--sys-prefix]
+    """
     _toggle_value = True
 
 
 class DisableNBExtensionApp(ToggleNBExtensionApp):
     """An App that disables nbextensions"""
     name = "jupyter nbextension disable"
-    description = "Disable an nbextension using frontend configuration files."
+    description = """
+    Enable an nbextension in frontend configuration.
+    
+    Usage
+        jupyter nbextension disable [--system|--sys-prefix]
+    """
     _toggle_value = None
 
 

--- a/notebook/serverextensions.py
+++ b/notebook/serverextensions.py
@@ -241,15 +241,16 @@ class ListServerExtensionsApp(BaseNBExtensionApp):
         """
         config_dirs = jupyter_config_path()
         for config_dir in config_dirs:
-            self.log.info(u'config dir: {}'.format(config_dir))
             cm = BaseJSONConfigManager(parent=self, config_dir=config_dir)
             data = cm.get("jupyter_notebook_config")
             server_extensions = (
                 data.setdefault("NotebookApp", {})
                 .setdefault("nbserver_extensions", {})
             )
+            if server_extensions:
+                print(u'config dir: {}'.format(config_dir))
             for import_name, enabled in server_extensions.items():
-                self.log.info(u'    {} {}'.format(
+                print(u'    {} {}'.format(
                               import_name,
                               GREEN_ENABLED if enabled else RED_DISABLED))
                 validate_serverextension(import_name, self.log)

--- a/notebook/serverextensions.py
+++ b/notebook/serverextensions.py
@@ -142,7 +142,13 @@ flags.update({
     "user" : ({
         "ToggleServerExtensionApp" : {
             "user" : True,
-        }}, "Install to the user's Jupyter directory"
+        }}, "Perform the operation for the current user"
+    ),
+    "system" : ({
+        "ToggleServerExtensionApp" : {
+            "user" : False,
+            "sys_prefix": False,
+        }}, "Perform the operation system-wide"
     ),
     "sys-prefix" : ({
         "ToggleServerExtensionApp" : {
@@ -217,14 +223,24 @@ class ToggleServerExtensionApp(BaseNBExtensionApp):
 class EnableServerExtensionApp(ToggleServerExtensionApp):
     """An App that enables (and validates) Server Extensions"""
     name = "jupyter serverextension enable"
-    description = "Enable a server extension using frontend configuration files."
+    description = """
+    Enable a serverextension in configuration.
+    
+    Usage
+        jupyter serverextension enable [--system|--sys-prefix]
+    """
     _toggle_value = True
 
 
 class DisableServerExtensionApp(ToggleServerExtensionApp):
     """An App that disables Server Extensions"""
     name = "jupyter serverextension disable"
-    description = "Disable an serverextension using frontend configuration files."
+    description = """
+    Disable a serverextension in configuration.
+    
+    Usage
+        jupyter serverextension disable [--system|--sys-prefix]
+    """
     _toggle_value = False
 
 


### PR DESCRIPTION
- use print for `nbextensions list` output, which should go to stdout without prefixes instead of logging
- add `--system` flag (opposite of `--user`, needed for enable/disable system-wide)
- update docs which had inaccurate references to `--user`
